### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ In addition to the properties and events defined above, the properties, events, 
 
 ### Starting the Implicit Grant Flow
 
-To start the implicit grant flow, invoke the ```BeginImplicitGrant()``` method. The ```Authorized``` event will be raised when the flow has completed.
+To start the implicit grant flow, invoke the ```BeginImplicitGrant()``` method. The ```Authenticated``` event will be raised when the flow has completed.
 
 ### Closing the Control
 


### PR DESCRIPTION
There is no `Authorized` event; the access token is passed as part of the `Authenticated` event.